### PR TITLE
Table methods with custom source column

### DIFF
--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -142,7 +142,6 @@ public class ObjectTable<T> extends Table<T>
     * @return this instance, to allow method chaining
     *
     * @see #filterRows(Predicate)
-    *
     * @since 1.4
     */
    public ObjectTable<T> hasLink(String sourceColumn, String targetColumn, String linkName)
@@ -707,7 +706,8 @@ public class ObjectTable<T> extends Table<T>
    }
 
    @Override
-   public <V, U> ObjectTable<U> expand(String sourceColumn, String targetColumn, Function<? super V, ? extends U> function)
+   public <V, U> ObjectTable<U> expand(String sourceColumn, String targetColumn,
+      Function<? super V, ? extends U> function)
    {
       this.expandImpl(sourceColumn, targetColumn, function);
       return this.view(targetColumn);

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -117,6 +117,32 @@ public class ObjectTable<T> extends Table<T>
    }
 
    /**
+    * Removes all rows where the cell value in the source column does not have the named link to the cell value in the
+    * target column.
+    * You can also pass the same column name twice to check for self-associations.
+    * <p>
+    * Essentially equivalent to:
+    *
+    * <pre>{@code
+    *    this.filterRows(row -> {
+    *       Object source = row.get(sourceColumn);
+    *       Object target = row.get(targetColumn);
+    *       Object linkValue = source.get<linkName>(); // via reflection
+    *       return linkValue == target || linkValue instanceof Collection && ((Collection) linkValue).contains(other);
+    *    });
+    * }</pre>
+    *
+    * @param sourceColumn
+    *    the column with source objects
+    * @param targetColumn
+    *    the column with target objects
+    * @param linkName
+    *    the name of the property on this table's objects
+    *
+    * @return this instance, to allow method chaining
+    *
+    * @see #filterRows(Predicate)
+    *
     * @since 1.4
     */
    public ObjectTable<T> hasLink(String sourceColumn, String targetColumn, String linkName)
@@ -186,6 +212,35 @@ public class ObjectTable<T> extends Table<T>
    }
 
    /**
+    * Removes all rows where the cell value in the source column does not have some link to the cell value in the target
+    * column.
+    * You can also the same column name twice to check for self-associations.
+    * <p>
+    * Essentially equivalent to:
+    *
+    * <pre>{@code
+    *    this.filterRows(row -> {
+    *       Object source = row.get(sourceColumn);
+    *       Object target = row.get(targetColumn);
+    *       for (String linkName : <properties of source>) {
+    *          Object linkValue = source.get<linkName>(); // via reflection
+    *          if (linkValue == target || linkValue instanceof Collection && ((Collection) linkValue).contains(other)) {
+    *             return true;
+    *          }
+    *       }
+    *       return false;
+    *    });
+    * }</pre>
+    *
+    * @param sourceColumn
+    *    the column with source objects
+    * @param targetColumn
+    *    the column with target objects
+    *
+    * @return this instance, to allow method chaining
+    *
+    * @see #filterRows(Predicate)
+    * @see #hasLink(String, String, String)
     * @since 1.4
     */
    public ObjectTable<T> hasAnyLink(String sourceColumn, String targetColumn)
@@ -267,6 +322,38 @@ public class ObjectTable<T> extends Table<T>
    }
 
    /**
+    * Creates a new column by expanding the given link from the cells in the source column.
+    * Links may be simple objects or collections, the latter of which will be flattened.
+    * Links that are {@code null} do not create a row.
+    * <p>
+    * Essentially equivalent to:
+    * <pre>{@code
+    *    this.expandAll(sourceColumn, targetColumn, source -> {
+    *       final Object target = source.get<linkName>(); // via reflection
+    *       if (target instanceof Collection) {
+    *          return target;
+    *       }
+    *       else if (target == null) {
+    *          return Collections.emptyList();
+    *       }
+    *       else {
+    *          return Collections.singleton(target);
+    *       }
+    *    }
+    * }</pre>
+    *
+    * @param <U>
+    *    the type of the target objects
+    * @param sourceColumn
+    *    the name of the column to operate on
+    * @param targetColumn
+    *    the name of the new column
+    * @param linkName
+    *    the name of the property to expand
+    *
+    * @return a table pointing to the new column
+    *
+    * @see #expandAll(String, String, Function)
     * @since 1.4
     */
    public <U> ObjectTable<U> expandLink(String sourceColumn, String targetColumn, String linkName)
@@ -333,6 +420,37 @@ public class ObjectTable<T> extends Table<T>
    }
 
    /**
+    * Creates a new column by expanding the all links and attributes from the cells in the source column.
+    * Links and attributes may be simple objects or collections, the latter of which will be flattened.
+    * Links and attributes that are {@code null} do not create a row.
+    * <p>
+    * Essentially equivalent to:
+    * <pre>{@code
+    *    this.expandAll(sourceColumn, targetColumn, source -> {
+    *       List<Object> result = new ArrayList<>();
+    *       for (String linkName : <properties of source>) {
+    *          final Object target = source.get<linkName>(); // via reflection
+    *          if (target instanceof Collection) {
+    *             result.addAll((Collection<?>) target);
+    *          }
+    *          else if (target != null) {
+    *             result.add(target);
+    *          }
+    *       }
+    *       return result;
+    *    }
+    * }</pre>
+    *
+    * @param <U>
+    *    the type of the target objects
+    * @param sourceColumn
+    *    the name of the column to operate on
+    * @param targetColumn
+    *    the name of the new column
+    *
+    * @return a table pointing to the new column
+    *
+    * @see #expandAll(String, String, Function)
     * @since 1.4
     */
    public <U> ObjectTable<U> expandAll(String sourceColumn, String targetColumn)
@@ -391,6 +509,27 @@ public class ObjectTable<T> extends Table<T>
    }
 
    /**
+    * Creates a new column by expanding the given attribute from cells in the source column.
+    * <p>
+    * Essentially equivalent to:
+    * <pre>{@code
+    *    this.expand(sourceColumn, targetColumn, start -> {
+    *       return start.get<attrName>(); // via reflection
+    *    });
+    * }</pre>
+    *
+    * @param <U>
+    *    the type of the attribute
+    * @param sourceColumn
+    *    the name of the column to operate on
+    * @param targetColumn
+    *    the name of the new column
+    * @param attrName
+    *    the name of the attribute to expand
+    *
+    * @return a table pointing to the new column
+    *
+    * @see #expand(String, String, Function)
     * @since 1.4
     */
    public <U> Table<U> expandAttribute(String sourceColumn, String targetColumn, String attrName)

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -232,7 +232,7 @@ public class ObjectTable<T> extends Table<T>
     */
    public <U> ObjectTable<U> expandLink(String newColumnName, String linkName)
    {
-      this.expandAllImpl(newColumnName, start -> {
+      this.expandAllImpl(this.getColumnName(), newColumnName, start -> {
          if (!this.reflectorMap.canReflect(start))
          {
             return Collections.emptySet();
@@ -489,7 +489,7 @@ public class ObjectTable<T> extends Table<T>
 
    private void expandAttributeImpl(String newColumnName, String attrName)
    {
-      this.expandImpl(newColumnName, start -> {
+      this.expandImpl(this.getColumnName(), newColumnName, start -> {
          if (!this.reflectorMap.canReflect(start))
          {
             return null;
@@ -507,7 +507,7 @@ public class ObjectTable<T> extends Table<T>
    @Override
    public <U> ObjectTable<U> expand(String columnName, Function<? super T, ? extends U> function)
    {
-      this.expandImpl(columnName, function);
+      this.expandImpl(this.getColumnName(), columnName, function);
       final ObjectTable<U> result = new ObjectTable<>(this);
       result.setColumnName_(columnName);
       return result;
@@ -517,7 +517,7 @@ public class ObjectTable<T> extends Table<T>
    public <U> ObjectTable<U> expandAll(String columnName,
       Function<? super T, ? extends Collection<? extends U>> function)
    {
-      this.expandAllImpl(columnName, function);
+      this.expandAllImpl(this.getColumnName(), columnName, function);
       final ObjectTable<U> result = new ObjectTable<>(this);
       result.setColumnName_(columnName);
       return result;

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -198,6 +198,13 @@ public class ObjectTable<T> extends Table<T>
 
    // --------------- Expansion ---------------
 
+   private <U> ObjectTable<U> view(String targetColumn)
+   {
+      ObjectTable<U> result = new ObjectTable<>(this);
+      result.setColumnName_(targetColumn);
+      return result;
+   }
+
    /**
     * Creates a new column by expanding the given link from the cells of the column this table points to.
     * Links may be simple objects or collections, the latter of which will be flattened.
@@ -240,7 +247,7 @@ public class ObjectTable<T> extends Table<T>
     */
    public <U> ObjectTable<U> expandLink(String sourceColumn, String targetColumn, String linkName)
    {
-      this.expandAllImpl(sourceColumn, targetColumn, start -> {
+      return this.expandAll(sourceColumn, targetColumn, start -> {
          if (!this.reflectorMap.canReflect(start))
          {
             return Collections.emptySet();
@@ -251,20 +258,17 @@ public class ObjectTable<T> extends Table<T>
 
          if (value instanceof Collection)
          {
-            return (Collection<?>) value;
+            return (Collection<U>) value;
          }
          else if (value != null)
          {
-            return Collections.singleton(value);
+            return Collections.singleton((U) value);
          }
          else
          {
             return Collections.emptySet();
          }
       });
-      ObjectTable<U> result = new ObjectTable<>(this);
-      result.setColumnName_(targetColumn);
-      return result;
    }
 
    /**
@@ -309,7 +313,7 @@ public class ObjectTable<T> extends Table<T>
     */
    public <U> ObjectTable<U> expandAll(String sourceColumn, String targetColumn)
    {
-      this.expandAllImpl(sourceColumn, targetColumn, start -> {
+      return this.expandAll(sourceColumn, targetColumn, start -> {
          if (!this.reflectorMap.canReflect(start))
          {
             return Collections.emptyList();
@@ -333,9 +337,6 @@ public class ObjectTable<T> extends Table<T>
 
          return result;
       });
-      ObjectTable<U> result = new ObjectTable<>(this);
-      result.setColumnName_(targetColumn);
-      return result;
    }
 
    /**
@@ -546,9 +547,7 @@ public class ObjectTable<T> extends Table<T>
    public <V, U> ObjectTable<U> expand(String sourceColumn, String targetColumn, Function<? super V, ? extends U> function)
    {
       this.expandImpl(sourceColumn, targetColumn, function);
-      final ObjectTable<U> result = new ObjectTable<>(this);
-      result.setColumnName_(targetColumn);
-      return result;
+      return this.view(targetColumn);
    }
 
    @Override
@@ -563,9 +562,7 @@ public class ObjectTable<T> extends Table<T>
       Function<? super V, ? extends Collection<? extends U>> function)
    {
       this.expandAllImpl(sourceColumn, targetColumn, function);
-      final ObjectTable<U> result = new ObjectTable<>(this);
-      result.setColumnName_(targetColumn);
-      return result;
+      return this.view(targetColumn);
    }
 
    @Override

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -212,7 +212,7 @@ public class ObjectTable<T> extends Table<T>
     * <p>
     * Essentially equivalent to:
     * <pre>{@code
-    *    this.expandAll(newColumnName, source -> {
+    *    this.expandAll(targetColumn, source -> {
     *       final Object target = source.get<linkName>(); // via reflection
     *       if (target instanceof Collection) {
     *          return target;
@@ -228,7 +228,7 @@ public class ObjectTable<T> extends Table<T>
     *
     * @param <U>
     *    the type of the target objects
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     * @param linkName
     *    the name of the property to expand
@@ -237,9 +237,9 @@ public class ObjectTable<T> extends Table<T>
     *
     * @see #expandAll(String, Function)
     */
-   public <U> ObjectTable<U> expandLink(String newColumnName, String linkName)
+   public <U> ObjectTable<U> expandLink(String targetColumn, String linkName)
    {
-      return this.expandLink(this.getColumnName(), newColumnName, linkName);
+      return this.expandLink(this.getColumnName(), targetColumn, linkName);
    }
 
    /**
@@ -278,7 +278,7 @@ public class ObjectTable<T> extends Table<T>
     * <p>
     * Essentially equivalent to:
     * <pre>{@code
-    *    this.expandAll(newColumnName, source -> {
+    *    this.expandAll(targetColumn, source -> {
     *       List<Object> result = new ArrayList<>();
     *       for (String linkName : <properties of source>) {
     *          final Object target = source.get<linkName>(); // via reflection
@@ -295,7 +295,7 @@ public class ObjectTable<T> extends Table<T>
     *
     * @param <U>
     *    the type of the target objects
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     *
     * @return a table pointing to the new column
@@ -303,9 +303,9 @@ public class ObjectTable<T> extends Table<T>
     * @see #expandLink(String, String)
     * @since 1.3
     */
-   public <U> ObjectTable<U> expandAll(String newColumnName)
+   public <U> ObjectTable<U> expandAll(String targetColumn)
    {
-      return this.expandAll(this.getColumnName(), newColumnName);
+      return this.expandAll(this.getColumnName(), targetColumn);
    }
 
    /**
@@ -344,14 +344,14 @@ public class ObjectTable<T> extends Table<T>
     * <p>
     * Essentially equivalent to:
     * <pre>{@code
-    *    this.expand(newColumnName, start -> {
+    *    this.expand(targetColumn, start -> {
     *       return start.get<attrName>(); // via reflection
     *    });
     * }</pre>
     *
     * @param <U>
     *    the type of the attribute
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     * @param attrName
     *    the name of the attribute to expand
@@ -361,9 +361,9 @@ public class ObjectTable<T> extends Table<T>
     * @see #expand(String, Function)
     * @since 1.2
     */
-   public <U> Table<U> expandAttribute(String newColumnName, String attrName)
+   public <U> Table<U> expandAttribute(String targetColumn, String attrName)
    {
-      return this.expandAttribute(this.getColumnName(), newColumnName, attrName);
+      return this.expandAttribute(this.getColumnName(), targetColumn, attrName);
    }
 
    /**
@@ -380,10 +380,10 @@ public class ObjectTable<T> extends Table<T>
    /**
     * Equivalent to:
     * <pre>{@code
-    *    this.expandAttribute(newColumnName, attrName).as(doubleTable.class);
+    *    this.expandAttribute(targetColumn, attrName).as(doubleTable.class);
     * }</pre>
     *
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     * @param attrName
     *    the name of the attribute to expand
@@ -392,21 +392,21 @@ public class ObjectTable<T> extends Table<T>
     *
     * @see #expandAttribute(String, String)
     */
-   public doubleTable expandDouble(String newColumnName, String attrName)
+   public doubleTable expandDouble(String targetColumn, String attrName)
    {
-      this.expandAttributeImpl(newColumnName, attrName);
+      this.expandAttributeImpl(targetColumn, attrName);
       doubleTable result = new doubleTable(this);
-      result.setColumnName_(newColumnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
    /**
     * Equivalent to:
     * <pre>{@code
-    *    this.expandAttribute(newColumnName, attrName).as(floatTable.class);
+    *    this.expandAttribute(targetColumn, attrName).as(floatTable.class);
     * }</pre>
     *
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     * @param attrName
     *    the name of the attribute to expand
@@ -415,21 +415,21 @@ public class ObjectTable<T> extends Table<T>
     *
     * @see #expandAttribute(String, String)
     */
-   public floatTable expandFloat(String newColumnName, String attrName)
+   public floatTable expandFloat(String targetColumn, String attrName)
    {
-      this.expandAttributeImpl(newColumnName, attrName);
+      this.expandAttributeImpl(targetColumn, attrName);
       floatTable result = new floatTable(this);
-      result.setColumnName_(newColumnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
    /**
     * Equivalent to:
     * <pre>{@code
-    *    this.expandAttribute(newColumnName, attrName).as(intTable.class);
+    *    this.expandAttribute(targetColumn, attrName).as(intTable.class);
     * }</pre>
     *
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     * @param attrName
     *    the name of the attribute to expand
@@ -438,21 +438,21 @@ public class ObjectTable<T> extends Table<T>
     *
     * @see #expandAttribute(String, String)
     */
-   public intTable expandInt(String newColumnName, String attrName)
+   public intTable expandInt(String targetColumn, String attrName)
    {
-      this.expandAttributeImpl(newColumnName, attrName);
+      this.expandAttributeImpl(targetColumn, attrName);
       intTable result = new intTable(this);
-      result.setColumnName_(newColumnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
    /**
     * Equivalent to:
     * <pre>{@code
-    *    this.expandAttribute(newColumnName, attrName).as(longTable.class);
+    *    this.expandAttribute(targetColumn, attrName).as(longTable.class);
     * }</pre>
     *
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     * @param attrName
     *    the name of the attribute to expand
@@ -461,21 +461,21 @@ public class ObjectTable<T> extends Table<T>
     *
     * @see #expandAttribute(String, String)
     */
-   public longTable expandLong(String newColumnName, String attrName)
+   public longTable expandLong(String targetColumn, String attrName)
    {
-      this.expandAttributeImpl(newColumnName, attrName);
+      this.expandAttributeImpl(targetColumn, attrName);
       longTable result = new longTable(this);
-      result.setColumnName_(newColumnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
    /**
     * Equivalent to:
     * <pre>{@code
-    *    this.expandAttribute(newColumnName, attrName).as(StringTable.class);
+    *    this.expandAttribute(targetColumn, attrName).as(StringTable.class);
     * }</pre>
     *
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     * @param attrName
     *    the name of the attribute to expand
@@ -484,21 +484,21 @@ public class ObjectTable<T> extends Table<T>
     *
     * @see #expandAttribute(String, String)
     */
-   public StringTable expandString(String newColumnName, String attrName)
+   public StringTable expandString(String targetColumn, String attrName)
    {
-      this.expandAttributeImpl(newColumnName, attrName);
+      this.expandAttributeImpl(targetColumn, attrName);
       StringTable result = new StringTable(this);
-      result.setColumnName_(newColumnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
    /**
     * Equivalent to:
     * <pre>{@code
-    *    this.expandAttribute(newColumnName, attrName).as(BooleanTable.class);
+    *    this.expandAttribute(targetColumn, attrName).as(BooleanTable.class);
     * }</pre>
     *
-    * @param newColumnName
+    * @param targetColumn
     *    the name of the new column
     * @param attrName
     *    the name of the attribute to expand
@@ -507,11 +507,11 @@ public class ObjectTable<T> extends Table<T>
     *
     * @see #expandAttribute(String, String)
     */
-   public BooleanTable expandBoolean(String newColumnName, String attrName)
+   public BooleanTable expandBoolean(String targetColumn, String attrName)
    {
-      this.expandAttributeImpl(newColumnName, attrName);
+      this.expandAttributeImpl(targetColumn, attrName);
       BooleanTable result = new BooleanTable(this);
-      result.setColumnName_(newColumnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
@@ -538,9 +538,9 @@ public class ObjectTable<T> extends Table<T>
    // --------------- Overriding Return Type as ObjectTable ---------------
 
    @Override
-   public <U> ObjectTable<U> expand(String columnName, Function<? super T, ? extends U> function)
+   public <U> ObjectTable<U> expand(String targetColumn, Function<? super T, ? extends U> function)
    {
-      return this.expand(this.getColumnName(), columnName, function);
+      return this.expand(this.getColumnName(), targetColumn, function);
    }
 
    @Override
@@ -551,10 +551,10 @@ public class ObjectTable<T> extends Table<T>
    }
 
    @Override
-   public <U> ObjectTable<U> expandAll(String columnName,
+   public <U> ObjectTable<U> expandAll(String targetColumn,
       Function<? super T, ? extends Collection<? extends U>> function)
    {
-      return this.expandAll(this.getColumnName(), columnName, function);
+      return this.expandAll(this.getColumnName(), targetColumn, function);
    }
 
    @Override

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -539,9 +539,15 @@ public class ObjectTable<T> extends Table<T>
    @Override
    public <U> ObjectTable<U> expand(String columnName, Function<? super T, ? extends U> function)
    {
-      this.expandImpl(this.getColumnName(), columnName, function);
+      return this.expand(this.getColumnName(), columnName, function);
+   }
+
+   @Override
+   public <V, U> ObjectTable<U> expand(String sourceColumn, String targetColumn, Function<? super V, ? extends U> function)
+   {
+      this.expandImpl(sourceColumn, targetColumn, function);
       final ObjectTable<U> result = new ObjectTable<>(this);
-      result.setColumnName_(columnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
@@ -549,9 +555,16 @@ public class ObjectTable<T> extends Table<T>
    public <U> ObjectTable<U> expandAll(String columnName,
       Function<? super T, ? extends Collection<? extends U>> function)
    {
-      this.expandAllImpl(this.getColumnName(), columnName, function);
+      return this.expandAll(this.getColumnName(), columnName, function);
+   }
+
+   @Override
+   public <V, U> ObjectTable<U> expandAll(String sourceColumn, String targetColumn,
+      Function<? super V, ? extends Collection<? extends U>> function)
+   {
+      this.expandAllImpl(sourceColumn, targetColumn, function);
       final ObjectTable<U> result = new ObjectTable<>(this);
-      result.setColumnName_(columnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
@@ -573,6 +586,13 @@ public class ObjectTable<T> extends Table<T>
    public ObjectTable<T> filter(Predicate<? super T> predicate)
    {
       super.filter(predicate);
+      return this;
+   }
+
+   @Override
+   public <V> ObjectTable<T> filter(String sourceColumn, Predicate<? super V> predicate)
+   {
+      super.filter(sourceColumn, predicate);
       return this;
    }
 

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -112,9 +112,23 @@ public class ObjectTable<T> extends Table<T>
    public ObjectTable<T> hasLink(String linkName, ObjectTable<?> otherTable)
    {
       this.checkSameData(otherTable);
+      this.hasLinkImpl(this.getColumnIndex(), otherTable.getColumnIndex(), linkName);
+      return this;
+   }
 
-      final int thisColumn = this.getColumnIndex();
-      final int otherColumn = otherTable.getColumnIndex();
+   /**
+    * @since 1.4
+    */
+   public ObjectTable<T> hasLink(String sourceColumn, String targetColumn, String linkName)
+   {
+      final int thisColumn = this.getColumnIndex(sourceColumn);
+      final int otherColumn = this.getColumnIndex(targetColumn);
+      this.hasLinkImpl(thisColumn, otherColumn, linkName);
+      return this;
+   }
+
+   private void hasLinkImpl(int thisColumn, int otherColumn, String linkName)
+   {
       this.table.removeIf(row -> {
          final Object source = row.get(thisColumn);
          final Object target = row.get(otherColumn);
@@ -130,7 +144,6 @@ public class ObjectTable<T> extends Table<T>
             linkValue == target || linkValue instanceof Collection && ((Collection<?>) linkValue).contains(target);
          return !keep;
       });
-      return this;
    }
 
    /**

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -200,8 +200,7 @@ public class ObjectTable<T> extends Table<T>
    public ObjectTable<T> hasAnyLink(ObjectTable<?> otherTable)
    {
       this.checkSameData(otherTable);
-      this.hasAnyLinkImpl(this.getColumnIndex(), otherTable.getColumnIndex());
-      return this;
+      return this.hasAnyLink(this.getColumnName(), otherTable.getColumnName());
    }
 
    /**
@@ -238,12 +237,8 @@ public class ObjectTable<T> extends Table<T>
     */
    public ObjectTable<T> hasAnyLink(String sourceColumn, String targetColumn)
    {
-      this.hasAnyLinkImpl(this.getColumnIndex(sourceColumn), this.getColumnIndex(targetColumn));
-      return this;
-   }
-
-   private void hasAnyLinkImpl(int thisColumn, int otherColumn)
-   {
+      final int thisColumn = this.getColumnIndex(sourceColumn);
+      final int otherColumn = this.getColumnIndex(targetColumn);
       this.table.removeIf(row -> {
          Object start = row.get(thisColumn);
          Object other = row.get(otherColumn);
@@ -266,6 +261,7 @@ public class ObjectTable<T> extends Table<T>
 
          return true;
       });
+      return this;
    }
 
    // --------------- Expansion ---------------

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -351,9 +351,17 @@ public class ObjectTable<T> extends Table<T>
     */
    public <U> Table<U> expandAttribute(String newColumnName, String attrName)
    {
-      this.expandAttributeImpl(newColumnName, attrName);
+      return this.expandAttribute(this.getColumnName(), newColumnName, attrName);
+   }
+
+   /**
+    * @since 1.4
+    */
+   public <U> Table<U> expandAttribute(String sourceColumn, String targetColumn, String attrName)
+   {
+      this.expandAttributeImpl(sourceColumn, targetColumn, attrName);
       final Table<U> result = new Table<>(this);
-      result.setColumnName_(newColumnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 
@@ -495,9 +503,14 @@ public class ObjectTable<T> extends Table<T>
       return result;
    }
 
-   private void expandAttributeImpl(String newColumnName, String attrName)
+   private void expandAttributeImpl(String targetColumn, String attrName)
    {
-      this.expandImpl(this.getColumnName(), newColumnName, start -> {
+      this.expandAttributeImpl(this.getColumnName(), targetColumn, attrName);
+   }
+
+   private void expandAttributeImpl(String sourceColumn, String targetColumn, String attrName)
+   {
+      this.expandImpl(sourceColumn, targetColumn, start -> {
          if (!this.reflectorMap.canReflect(start))
          {
             return null;

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -301,7 +301,15 @@ public class ObjectTable<T> extends Table<T>
     */
    public <U> ObjectTable<U> expandAll(String newColumnName)
    {
-      return this.expandAll(newColumnName, start -> {
+      return this.expandAll(this.getColumnName(), newColumnName);
+   }
+
+   /**
+    * @since 1.4
+    */
+   public <U> ObjectTable<U> expandAll(String sourceColumn, String targetColumn)
+   {
+      this.expandAllImpl(sourceColumn, targetColumn, start -> {
          if (!this.reflectorMap.canReflect(start))
          {
             return Collections.emptyList();
@@ -325,6 +333,9 @@ public class ObjectTable<T> extends Table<T>
 
          return result;
       });
+      ObjectTable<U> result = new ObjectTable<>(this);
+      result.setColumnName_(targetColumn);
+      return result;
    }
 
    /**

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -232,7 +232,15 @@ public class ObjectTable<T> extends Table<T>
     */
    public <U> ObjectTable<U> expandLink(String newColumnName, String linkName)
    {
-      this.expandAllImpl(this.getColumnName(), newColumnName, start -> {
+      return this.expandLink(this.getColumnName(), newColumnName, linkName);
+   }
+
+   /**
+    * @since 1.4
+    */
+   public <U> ObjectTable<U> expandLink(String sourceColumn, String targetColumn, String linkName)
+   {
+      this.expandAllImpl(sourceColumn, targetColumn, start -> {
          if (!this.reflectorMap.canReflect(start))
          {
             return Collections.emptySet();
@@ -255,7 +263,7 @@ public class ObjectTable<T> extends Table<T>
          }
       });
       ObjectTable<U> result = new ObjectTable<>(this);
-      result.setColumnName_(newColumnName);
+      result.setColumnName_(targetColumn);
       return result;
    }
 

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -181,9 +181,21 @@ public class ObjectTable<T> extends Table<T>
    public ObjectTable<T> hasAnyLink(ObjectTable<?> otherTable)
    {
       this.checkSameData(otherTable);
+      this.hasAnyLinkImpl(this.getColumnIndex(), otherTable.getColumnIndex());
+      return this;
+   }
 
-      final int thisColumn = this.getColumnIndex();
-      final int otherColumn = otherTable.getColumnIndex();
+   /**
+    * @since 1.4
+    */
+   public ObjectTable<T> hasAnyLink(String sourceColumn, String targetColumn)
+   {
+      this.hasAnyLinkImpl(this.getColumnIndex(sourceColumn), this.getColumnIndex(targetColumn));
+      return this;
+   }
+
+   private void hasAnyLinkImpl(int thisColumn, int otherColumn)
+   {
       this.table.removeIf(row -> {
          Object start = row.get(thisColumn);
          Object other = row.get(otherColumn);
@@ -206,7 +218,6 @@ public class ObjectTable<T> extends Table<T>
 
          return true;
       });
-      return this;
    }
 
    // --------------- Expansion ---------------

--- a/src/main/java/org/fulib/tables/ObjectTable.java
+++ b/src/main/java/org/fulib/tables/ObjectTable.java
@@ -112,8 +112,7 @@ public class ObjectTable<T> extends Table<T>
    public ObjectTable<T> hasLink(String linkName, ObjectTable<?> otherTable)
    {
       this.checkSameData(otherTable);
-      this.hasLinkImpl(this.getColumnIndex(), otherTable.getColumnIndex(), linkName);
-      return this;
+      return this.hasLink(this.getColumnName(), otherTable.getColumnName(), linkName);
    }
 
    /**
@@ -148,12 +147,6 @@ public class ObjectTable<T> extends Table<T>
    {
       final int thisColumn = this.getColumnIndex(sourceColumn);
       final int otherColumn = this.getColumnIndex(targetColumn);
-      this.hasLinkImpl(thisColumn, otherColumn, linkName);
-      return this;
-   }
-
-   private void hasLinkImpl(int thisColumn, int otherColumn, String linkName)
-   {
       this.table.removeIf(row -> {
          final Object source = row.get(thisColumn);
          final Object target = row.get(otherColumn);
@@ -169,6 +162,7 @@ public class ObjectTable<T> extends Table<T>
             linkValue == target || linkValue instanceof Collection && ((Collection<?>) linkValue).contains(target);
          return !keep;
       });
+      return this;
    }
 
    /**

--- a/src/main/java/org/fulib/tables/Table.java
+++ b/src/main/java/org/fulib/tables/Table.java
@@ -464,7 +464,8 @@ public class Table<T> implements Iterable<T>
     *
     * @since 1.4
     */
-   public <V, U> Table<U> expandAll(String sourceColumn, String targetColumn, Function<? super V, ? extends Collection<? extends U>> function)
+   public <V, U> Table<U> expandAll(String sourceColumn, String targetColumn,
+      Function<? super V, ? extends Collection<? extends U>> function)
    {
       this.expandAllImpl(sourceColumn, targetColumn, function);
       final Table<U> result = new Table<>(this);
@@ -472,7 +473,8 @@ public class Table<T> implements Iterable<T>
       return result;
    }
 
-   <V> void expandAllImpl(String sourceColumn, String targetColumn, Function<? super V, ? extends Collection<?>> function)
+   <V> void expandAllImpl(String sourceColumn, String targetColumn,
+      Function<? super V, ? extends Collection<?>> function)
    {
       final int column = this.getColumnIndex(sourceColumn);
       this.addColumn(targetColumn);

--- a/src/main/java/org/fulib/tables/Table.java
+++ b/src/main/java/org/fulib/tables/Table.java
@@ -392,7 +392,7 @@ public class Table<T> implements Iterable<T>
     *
     * @param <U>
     *    the cell type of the new column
-    * @param columnName
+    * @param targetColumn
     *    the name of the new column
     * @param function
     *    the function that computes a collection of values for the new column
@@ -401,9 +401,9 @@ public class Table<T> implements Iterable<T>
     *
     * @since 1.2
     */
-   public <U> Table<U> expandAll(String columnName, Function<? super T, ? extends Collection<? extends U>> function)
+   public <U> Table<U> expandAll(String targetColumn, Function<? super T, ? extends Collection<? extends U>> function)
    {
-      return expandAll(this.columnName, columnName, function);
+      return expandAll(this.columnName, targetColumn, function);
    }
 
    /**
@@ -1163,16 +1163,16 @@ public class Table<T> implements Iterable<T>
    /**
     * @param <V>
     *    the cell type of the column to operate on
-    * @param columnName
+    * @param sourceColumn
     *    the name of the column to operate on
     *
     * @return a list of cell values of the given column
     *
     * @since 1.4
     */
-   public <V> List<V> toList(String columnName)
+   public <V> List<V> toList(String sourceColumn)
    {
-      return this.<V>stream(columnName).collect(Collectors.toList());
+      return this.<V>stream(sourceColumn).collect(Collectors.toList());
    }
 
    /**
@@ -1186,16 +1186,16 @@ public class Table<T> implements Iterable<T>
    /**
     * @param <V>
     *    the cell type of the column to operate on
-    * @param columnName
+    * @param sourceColumn
     *    the name of the column to operate on
     *
     * @return a set of cell values of the given column
     *
     * @since 1.4
     */
-   public <V> Set<V> toSet(String columnName)
+   public <V> Set<V> toSet(String sourceColumn)
    {
-      return this.<V>stream(columnName).collect(Collectors.toCollection(LinkedHashSet::new));
+      return this.<V>stream(sourceColumn).collect(Collectors.toCollection(LinkedHashSet::new));
    }
 
    /**
@@ -1211,16 +1211,16 @@ public class Table<T> implements Iterable<T>
    /**
     * @param <V>
     *    the cell type of the column to operate on
-    * @param columnName
+    * @param sourceColumn
     *    the name of the column to operate on
     *
     * @return a stream of cell values of the given column
     *
     * @since 1.4
     */
-   public <V> Stream<V> stream(String columnName)
+   public <V> Stream<V> stream(String sourceColumn)
    {
-      int column = this.getColumnIndex(columnName);
+      int column = this.getColumnIndex(sourceColumn);
       return this.table.stream().map(l -> (V) l.get(column));
    }
 

--- a/src/main/java/org/fulib/tables/Table.java
+++ b/src/main/java/org/fulib/tables/Table.java
@@ -236,7 +236,6 @@ public class Table<T> implements Iterable<T>
     * Table<Integer> b = a.expand("B", i -> i * 2);
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.expand.b -->
     * <table>
     *     <caption>
@@ -361,7 +360,6 @@ public class Table<T> implements Iterable<T>
     * Table<Integer> b = a.expandAll("B", i -> Arrays.asList(i + 10, i + 20));
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.expandAll.b -->
     * <table>
     *     <caption>
@@ -504,7 +502,6 @@ public class Table<T> implements Iterable<T>
     * Table<Integer> c = b.derive("C", row -> (int) row.get("A") + (int) row.get("B"));
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.derive.c -->
     * <table>
     *     <caption>
@@ -573,7 +570,6 @@ public class Table<T> implements Iterable<T>
     * });
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.deriveAll.c -->
     * <table>
     *     <caption>
@@ -661,7 +657,6 @@ public class Table<T> implements Iterable<T>
     * Table<String> lowercase = names.expand("lowercase", String::toLowerCase);
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.dropColumns.before -->
     * <table>
     *     <caption>
@@ -694,13 +689,11 @@ public class Table<T> implements Iterable<T>
     *     </tr>
     * </table>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.dropColumns.select | javadoc -->
     * <pre>{@code
     * names.dropColumns(names.getColumnName());
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.dropColumns.after -->
     * <table>
     *     <caption>
@@ -724,7 +717,6 @@ public class Table<T> implements Iterable<T>
     *     </tr>
     * </table>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.dropColumns.exception | javadoc -->
     * <pre>{@code
     * names.toList(); // throws IllegalStateException
@@ -789,7 +781,6 @@ public class Table<T> implements Iterable<T>
     * Table<String> lowercase = names.expand("lowercase", String::toLowerCase);
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.selectColumns.before -->
     * <table>
     *     <caption>
@@ -822,13 +813,11 @@ public class Table<T> implements Iterable<T>
     *     </tr>
     * </table>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.selectColumns.select | javadoc -->
     * <pre>{@code
     * names.selectColumns("uppercase", "lowercase");
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.selectColumns.after -->
     * <table>
     *     <caption>
@@ -852,7 +841,6 @@ public class Table<T> implements Iterable<T>
     *     </tr>
     * </table>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.selectColumns.exception | javadoc -->
     * <pre>{@code
     * names.toList(); // throws IllegalStateException
@@ -903,7 +891,6 @@ public class Table<T> implements Iterable<T>
     * numbers.filter(i -> i % 2 == 0);
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.filter.result -->
     * <table>
     *     <caption>
@@ -1013,7 +1000,6 @@ public class Table<T> implements Iterable<T>
     * Table<Integer> b = a.expandAll("B", i -> Arrays.asList(1, 2));
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.filterRows.before -->
     * <table>
     *     <caption>
@@ -1041,13 +1027,11 @@ public class Table<T> implements Iterable<T>
     *     </tr>
     * </table>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.filterRows.action | javadoc -->
     * <pre>{@code
     * a.filterRows(row -> (int) row.get("A") != (int) row.get("B"));
     * }</pre>
     * <!-- end_code_fragment: -->
-    * <p>
     * <!-- insert_code_fragment: TableTest.filterRows.after -->
     * <table>
     *     <caption>

--- a/src/main/java/org/fulib/tables/Table.java
+++ b/src/main/java/org/fulib/tables/Table.java
@@ -278,6 +278,57 @@ public class Table<T> implements Iterable<T>
    }
 
    /**
+    * Creates a new column with the given name by applying the given function to each object in the given column.
+    * <p>
+    * Example:
+    * <!-- insert_code_fragment: TableTest.expand.source | javadoc -->
+    * <pre>{@code
+    * Table<Integer> a = new Table<>("A", 1, 2, 3);
+    * a.expand("B", i -> i * 2);
+    * Table<Integer> c = a.expand("B", "C", (Integer i) -> i + 1);
+    * }</pre>
+    * <!-- end_code_fragment: -->
+    * <!-- insert_code_fragment: TableTest.expand.source.c -->
+    * <table>
+    *     <caption>
+    *         c
+    *     </caption>
+    *     <tr>
+    *         <th>A</th>
+    *         <th>B</th>
+    *         <th>C</th>
+    *     </tr>
+    *     <tr>
+    *         <td>1</td>
+    *         <td>2</td>
+    *         <td>3</td>
+    *     </tr>
+    *     <tr>
+    *         <td>2</td>
+    *         <td>4</td>
+    *         <td>5</td>
+    *     </tr>
+    *     <tr>
+    *         <td>3</td>
+    *         <td>6</td>
+    *         <td>7</td>
+    *     </tr>
+    * </table>
+    * <!-- end_code_fragment: -->
+    *
+    * @param <V>
+    *    the cell type of the column to operate on
+    * @param <U>
+    *    the cell type of the new column
+    * @param sourceColumn
+    *    the name of the column to operate on
+    * @param targetColumn
+    *    the name of the new column
+    * @param function
+    *    the function that computes a value for the new column
+    *
+    * @return a table pointing to the new column
+    *
     * @since 1.4
     */
    public <V, U> Table<U> expand(String sourceColumn, String targetColumn, Function<? super V, ? extends U> function)
@@ -356,6 +407,63 @@ public class Table<T> implements Iterable<T>
    }
 
    /**
+    * Creates a new column with the given name by applying the given function to each object in the given column,
+    * and flattening the result.
+    * <p>
+    * Example:
+    * <!-- insert_code_fragment: TableTest.expandAll.source | javadoc -->
+    * <pre>{@code
+    * Table<Integer> a = new Table<>("A", 1, 2);
+    * a.expand("B", i -> i * 2);
+    * Table<Integer> c = a.expandAll("B", "C", (Integer i) -> Arrays.asList(i + 10, i + 20));
+    * }</pre>
+    * <!-- end_code_fragment: -->
+    * <!-- insert_code_fragment: TableTest.expandAll.source.c -->
+    * <table>
+    *     <caption>
+    *         c
+    *     </caption>
+    *     <tr>
+    *         <th>A</th>
+    *         <th>B</th>
+    *         <th>C</th>
+    *     </tr>
+    *     <tr>
+    *         <td>1</td>
+    *         <td>2</td>
+    *         <td>12</td>
+    *     </tr>
+    *     <tr>
+    *         <td>1</td>
+    *         <td>2</td>
+    *         <td>22</td>
+    *     </tr>
+    *     <tr>
+    *         <td>2</td>
+    *         <td>4</td>
+    *         <td>14</td>
+    *     </tr>
+    *     <tr>
+    *         <td>2</td>
+    *         <td>4</td>
+    *         <td>24</td>
+    *     </tr>
+    * </table>
+    * <!-- end_code_fragment: -->
+    *
+    * @param <V>
+    *    the cell type of the column to operate on
+    * @param <U>
+    *    the cell type of the new column
+    * @param sourceColumn
+    *    the name of the column to operate on
+    * @param targetColumn
+    *    the name of the new column
+    * @param function
+    *    the function that computes a collection of values for the new column
+    *
+    * @return a table pointing to the new column
+    *
     * @since 1.4
     */
    public <V, U> Table<U> expandAll(String sourceColumn, String targetColumn, Function<? super V, ? extends Collection<? extends U>> function)
@@ -833,6 +941,58 @@ public class Table<T> implements Iterable<T>
    }
 
    /**
+    * Removes all rows from this table for which the predicate returned {@code false} when passed the cell value in the
+    * given column.
+    * <p>
+    * Example:
+    * <!-- insert_code_fragment: TableTest.filter.source | javadoc -->
+    * <pre>{@code
+    * Table<Integer> a = new Table<>("A", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    * a.expand("B", i -> i + 1);
+    * a.filter("B", (Integer i) -> i % 2 == 0);
+    * }</pre>
+    * <!-- end_code_fragment: -->
+    * <!-- insert_code_fragment: TableTest.filter.source.result -->
+    * <table>
+    *     <caption>
+    *         result
+    *     </caption>
+    *     <tr>
+    *         <th>A</th>
+    *         <th>B</th>
+    *     </tr>
+    *     <tr>
+    *         <td>1</td>
+    *         <td>2</td>
+    *     </tr>
+    *     <tr>
+    *         <td>3</td>
+    *         <td>4</td>
+    *     </tr>
+    *     <tr>
+    *         <td>5</td>
+    *         <td>6</td>
+    *     </tr>
+    *     <tr>
+    *         <td>7</td>
+    *         <td>8</td>
+    *     </tr>
+    *     <tr>
+    *         <td>9</td>
+    *         <td>10</td>
+    *     </tr>
+    * </table>
+    * <!-- end_code_fragment: -->
+    *
+    * @param <V>
+    *    the cell type of the column to operate on
+    * @param sourceColumn
+    *    the name of the column to operate on
+    * @param predicate
+    *    the predicate that determines which rows should be kept
+    *
+    * @return this table, to allow method chaining
+    *
     * @since 1.4
     */
    public <V> Table<T> filter(String sourceColumn, Predicate<? super V> predicate)
@@ -962,6 +1122,13 @@ public class Table<T> implements Iterable<T>
    }
 
    /**
+    * {@inheritDoc}
+    *
+    * @param sourceColumn
+    *    the name of the column to operate on
+    *
+    * @return an iterator over the cell values of the given column
+    *
     * @since 1.4
     */
    public <V> Iterator<V> iterator(String sourceColumn)
@@ -994,6 +1161,13 @@ public class Table<T> implements Iterable<T>
    }
 
    /**
+    * @param <V>
+    *    the cell type of the column to operate on
+    * @param columnName
+    *    the name of the column to operate on
+    *
+    * @return a list of cell values of the given column
+    *
     * @since 1.4
     */
    public <V> List<V> toList(String columnName)
@@ -1010,6 +1184,13 @@ public class Table<T> implements Iterable<T>
    }
 
    /**
+    * @param <V>
+    *    the cell type of the column to operate on
+    * @param columnName
+    *    the name of the column to operate on
+    *
+    * @return a set of cell values of the given column
+    *
     * @since 1.4
     */
    public <V> Set<V> toSet(String columnName)
@@ -1028,6 +1209,13 @@ public class Table<T> implements Iterable<T>
    }
 
    /**
+    * @param <V>
+    *    the cell type of the column to operate on
+    * @param columnName
+    *    the name of the column to operate on
+    *
+    * @return a stream of cell values of the given column
+    *
     * @since 1.4
     */
    public <V> Stream<V> stream(String columnName)

--- a/src/test/java/org/fulib/tables/TableTest.java
+++ b/src/test/java/org/fulib/tables/TableTest.java
@@ -28,6 +28,20 @@ public class TableTest
    }
 
    @Test
+   public void expandWithSource()
+   {
+      // start_code_fragment: TableTest.expand.source
+      Table<Integer> a = new Table<>("A", 1, 2, 3);
+      a.expand("B", i -> i * 2);
+      Table<Integer> c = a.expand("B", "C", (Integer i) -> i + 1);
+      // end_code_fragment:
+
+      fragments.addFragment("TableTest.expand.source.c", new HtmlRenderer().setCaption("c").render(c));
+
+      assertEquals(Arrays.asList(3, 5, 7), a.toList("C"));
+   }
+
+   @Test
    public void expandAll()
    {
       // start_code_fragment: TableTest.expandAll
@@ -39,6 +53,21 @@ public class TableTest
 
       assertEquals("B", b.getColumnName());
       assertEquals(Arrays.asList(11, 21, 12, 22), b.toList());
+   }
+
+   @Test
+   public void expandAllWithSource()
+   {
+      // start_code_fragment: TableTest.expandAll.source
+      Table<Integer> a = new Table<>("A", 1, 2);
+      a.expand("B", i -> i * 2);
+      Table<Integer> c = a.expandAll("B", "C", (Integer i) -> Arrays.asList(i + 10, i + 20));
+      // end_code_fragment:
+
+      fragments.addFragment("TableTest.expandAll.source.c", new HtmlRenderer().setCaption("c").render(c));
+
+      assertEquals("C", c.getColumnName());
+      assertEquals(Arrays.asList(12, 22, 14, 24), c.toList());
    }
 
    @Test
@@ -186,6 +215,21 @@ public class TableTest
       assertEquals(Arrays.asList(2, 4, 6, 8, 10), numbers.toList());
 
       fragments.addFragment("TableTest.filter.result", new HtmlRenderer().setCaption("result").render(numbers));
+   }
+
+   @Test
+   public void filterWithSource()
+   {
+      // start_code_fragment: TableTest.filter.source
+      Table<Integer> a = new Table<>("A", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+      a.expand("B", i -> i + 1);
+      a.filter("B", (Integer i) -> i % 2 == 0);
+      // end_code_fragment:
+
+      assertEquals(Arrays.asList(1, 3, 5, 7, 9), a.toList());
+      assertEquals(Arrays.asList(2, 4, 6, 8, 10), a.toList("B"));
+
+      fragments.addFragment("TableTest.filter.source.result", new HtmlRenderer().setCaption("result").render(a));
    }
 
    @Test


### PR DESCRIPTION
This serves as a replacement for #10 with reduced duplication.

## New Features

+ Added many new `Table` and `ObjectTable` methods that allow specifying the source column name.
